### PR TITLE
Enabling Dark by Default

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,7 +9,7 @@ const { title, description, slug, image, keywords } = content;
 const permalink = generatePermalink(slug);
 ---
 
-<html lang={content.lang || "en"}>
+<html lang={content.lang || "en"} class="dark">
   <head>
     <BaseHead {title} {description} {permalink} {image} {keywords} />
   </head>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
 	content: ['./public/**/*.html', './src/**/*.{astro,html,js,jsx,md,svelte,ts,tsx,vue}'],
+	darkMode: ["class"],
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
The styles in article tag aren't rendering correctly if the user's preferred color scheme isn't dark. You can test this by using preferred color scheme light in DevTools or your OS:

![image](https://github.com/BrockHerion/brockherion.dev/assets/77650775/912d6b6d-f4db-4e8a-8f9e-6d84eac4a280)

This enables dark color scheme by default to avoid changing the styles on the page. Feel free to edit as you need.